### PR TITLE
Add xdebug support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,6 @@ services:
         command: --default-authentication-plugin=mysql_native_password --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
         restart: always # always restart unless stopped manually
         environment:
-            MYSQL_USER: root
             MYSQL_ROOT_PASSWORD: secret
             MYSQL_PASSWORD: secret
         networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,10 +26,13 @@ services:
             context: .
             dockerfile: ./php/Dockerfile
         container_name: php74-container
+        extra_hosts:
+            - "host.docker.internal:host-gateway"
         ports:
             - "9000:9000"
         volumes:
             - ./app:/var/www/project
+            - ./php/xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini
         networks:
             - nginx-php74-mysql8-node
 
@@ -44,6 +47,7 @@ services:
         command: --default-authentication-plugin=mysql_native_password --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
         restart: always # always restart unless stopped manually
         environment:
+            MYSQL_USER: root
             MYSQL_ROOT_PASSWORD: secret
             MYSQL_PASSWORD: secret
         networks:

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -3,6 +3,7 @@ FROM php:7.4-fpm
 RUN apt-get update && apt-get install -y zlib1g-dev g++ git libicu-dev zip libzip-dev zip \
     && docker-php-ext-install intl opcache pdo pdo_mysql \
     && pecl install apcu \
+    && pecl install xdebug \
     && docker-php-ext-enable apcu \
     && docker-php-ext-configure zip \
     && docker-php-ext-install zip

--- a/php/xdebug.ini
+++ b/php/xdebug.ini
@@ -1,0 +1,5 @@
+[xdebug]
+zend_extension=xdebug.so
+xdebug.mode=develop,debug
+xdebug.discover_client_host=0
+xdebug.client_host=host.docker.internal


### PR DESCRIPTION
xdebug is first thing I always install in any project while developing, I belive others are doing the same.

Note: except this I needed to allow port 9003 in firewall (Linux)